### PR TITLE
[ADD] maxBuffer option for large projects

### DIFF
--- a/tasks/coffeescript_concat.js
+++ b/tasks/coffeescript_concat.js
@@ -9,8 +9,9 @@
 'use strict';
 
 // TODO: rewrite the coffeescript-concat so it is launchable directly, without executing
-var exec = require('child_process').exec;
-var coffeescript_concatPath = require.resolve('coffeescript-concat');
+var exec = require('child_process').exec,
+    coffeescript_concatPath = require.resolve('coffeescript-concat'),
+    Q = require('q');
 
 module.exports = function(grunt) {
 
@@ -24,7 +25,8 @@ module.exports = function(grunt) {
       includeFolders: []
     });
 
-    var done = this.async();
+    var allTasksDone = this.async(),
+        deferreds = [];
 
     // Iterate over all specified file groups.
     this.files.forEach(function(f) {
@@ -44,22 +46,23 @@ module.exports = function(grunt) {
         include = ' -I ' + options.includeFolders.join(' ');
       }
 
-      var optionMaxBuffer = 200 * 1024;
-      if (options.maxBuffer && typeof options.maxBuffer === 'number') {
-        optionMaxBuffer = options.maxBuffer;
-      }
-
-      exec('node ' + coffeescript_concatPath + ' ' + include + ' ' + files.join(" "),{maxBuffer: optionMaxBuffer}, function (error, stdout, stderr) {
+          var deferred = Q.defer();
+          deferreds.push(deferred);
+      exec('node ' + coffeescript_concatPath + ' ' + include + ' ' + files.join(" "), function (error, stdout) {
           if (error) {
-            console.error(error);
-            return done(error);
+            grunt.log.error(error);
+            return deferred.reject(error);
           }
           // coffeescript-concat library itself can write to file too via -o command, but grunt can create directories as well, preventing ENOENT errors
           grunt.file.write(f.dest, stdout);
           // Print a success message.
           grunt.log.writeln('File "' + f.dest + '" created.');
-          done();
+          deferred.resolve();
       });
+    });
+
+    Q.all(deferreds.map(function(d) { return d.promise; })).fin(function() {
+      allTasksDone();
     });
   });
 

--- a/tasks/coffeescript_concat.js
+++ b/tasks/coffeescript_concat.js
@@ -46,9 +46,14 @@ module.exports = function(grunt) {
         include = ' -I ' + options.includeFolders.join(' ');
       }
 
+      var optionMaxBuffer = 200 * 1024;
+      if (options.maxBuffer && typeof options.maxBuffer === 'number') {
+        optionMaxBuffer = options.maxBuffer;
+      }
+
           var deferred = Q.defer();
           deferreds.push(deferred);
-      exec('node ' + coffeescript_concatPath + ' ' + include + ' ' + files.join(" "), function (error, stdout) {
+      exec('node ' + coffeescript_concatPath + ' ' + include + ' ' + files.join(" "), {maxBuffer: optionMaxBuffer}, function (error, stdout) {
           if (error) {
             grunt.log.error(error);
             return deferred.reject(error);


### PR DESCRIPTION
As the [documentation](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) states, the maxBuffer size is 200kb by default for `exec` child processes. Which can be a problem when working on larger projects.

This PR adds the avaibility to override this default value by passing the `maxBuffer` option to the task.